### PR TITLE
feat: add additional actors for a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Actor Directory buttons:
     *   Variables
         *   Define a folder new actors (default is "Heroes").
         *   Provide a comma-separated list of usernames (e.g., Valeros,Seoni,Kyra).
-        *   Use a `+N` to create additional actors for a user (e.g., Valeros+2,Seoni,Kyra creates two additonal actors assigned to Valeros). Helpful for heroes with followers or summons.
+        *   Use a `+N` to create additional actors for a user (e.g., Valeros+2,Seoni,Kyra creates two additional actors assigned to Valeros). Helpful for heroes with followers or summons.
     *   Outputs
         *   Assign randomly generated passwords.
         *   Create a blank actor for each user and assign it to them

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Actor Directory buttons:
     *   Variables
         *   Define a folder new actors (default is "Heroes").
         *   Provide a comma-separated list of usernames (e.g., Valeros,Seoni,Kyra).
+        *   Use a `+N` to create additional actors for a user (e.g., Valeros+2,Seoni,Kyra creates two additonal actors assigned to Valeros). Helpful for heroes with followers or summons.
     *   Outputs
         *   Assign randomly generated passwords.
         *   Create a blank actor for each user and assign it to them

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Character Vault
 
+## 2.2.1
+
+- Add feature to add addtional actors isung a `+N` to create additional actors for a user (e.g., Valeros+2,Seoni,Kyra creates two additional actors assigned to Valeros)
+- Add option to select alternate git folder for import/export
+
 ## 2.2.0
 
 - Add Foundry VTT v14 compatibility

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 const MODULE_ID = "character-vault";
-import { copyGmHotbar } from './src/utils.js';
+import {
+    copyGmHotbar,
+    fetchGitHubFolderList
+} from './src/utils.js';
 
 // Register Access Token, Path, and Repo as Game Settings
 Hooks.once('init', () => {
@@ -13,8 +16,8 @@ Hooks.once('init', () => {
     });
 
     game.settings.register(MODULE_ID, "githubPath", {
-        name: "GitHub Path",
-        hint: "The path within the GitHub repository to the folder containing the actor JSON files.",
+        name: "Default GitHub Path",
+        hint: "The default folder path from GitHub repository containing actor JSON files.",
         scope: "world",
         config: true,
         type: String,
@@ -56,6 +59,7 @@ import {
     importActorFromGitHubToActor
 } from './src/importActors.js';
 import {
+    openActorUploadDialog,
     openFolderUploadDialog,
     uploadActorToGitHub,
 } from './src/uploadActors.js';
@@ -63,9 +67,12 @@ import {
 Hooks.once("ready", () => {
     const exports = {
         fetchGitHubActorList,
+        fetchGitHubFolderList,
         openImportDialog,
         importActorFromGitHubToActor,
         openFolderImportDialog,
+        openActorUploadDialog,
+        uploadActorToGitHub,
     };
     Object.entries(exports).forEach(([key, fn]) => window[key] = fn);
     console.log("Character Vault: Functions are now globally available.");
@@ -146,19 +153,34 @@ Hooks.on("renderMacroDirectory", (app, html, data) => {
 
 // Context Menu Function
 Hooks.on("getActorContextOptions", (html, options) => {
-    const getActor = (/** @type {HTMLElement} */ li) => game.actors.get(li.dataset.entryId);
+    const getActor = (...args) => {
+        for (const arg of args) {
+            const element = arg instanceof HTMLElement ? arg : arg?.currentTarget ?? arg?.target;
+            const row = element?.dataset?.entryId ? element : element?.closest?.("[data-entry-id]");
+            const actor = row ? game.actors.get(row.dataset.entryId) : null;
+            if (actor) return actor;
+        }
+
+        return null;
+    };
 
     options.push({
-        name: "Import from GitHub",
+        label: "Import from GitHub",
         icon: '<i class="fa-solid fa-cloud-arrow-down"></i>',
-        condition: (li) => getActor(li)?.isOwner,
-        callback: (li) => openImportDialog(getActor(li).id)
+        visible: (li) => getActor(li)?.isOwner,
+        onClick: (event, li) => {
+            const actor = getActor(li, event);
+            if (actor) openImportDialog(actor.id);
+        }
     });
 
     options.push({
-        name: "Export to GitHub",
+        label: "Export to GitHub",
         icon: '<i class="fa-solid fa-cloud-arrow-up"></i>',
-        condition: (li) => game.user.isGM && getActor(li)?.isOwner,
-        callback: (li) => uploadActorToGitHub(getActor(li))
+        visible: (li) => game.user.isGM && getActor(li)?.isOwner,
+        onClick: (event, li) => {
+            const actor = getActor(li, event);
+            if (actor) openActorUploadDialog(actor);
+        }
     });
 });

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "14.359"
+    "verified": "14.365"
   },
   "description": "Store actor JSON files in a GitHub repo and import the data into your world and export back to the repo. Useful for managing West Marches or society type play where players can bring their actors through a persistent world with multiple Game Masters and Foundry VTT servers.",
   "authors": [

--- a/src/createUsers.js
+++ b/src/createUsers.js
@@ -1,6 +1,7 @@
 const MODULE_ID = "character-vault";
 const WORDLIST_URL = `modules/${MODULE_ID}/src/wordlist.txt`;
 const FALLBACK_WORDLIST = ["tiger", "rabbit", "blue", "green", "apple", "banana", "berry", "orange"];
+const MAX_ADDITIONAL_ACTORS = 20;
 let WordlistCache = null;
 
 export async function generateUsers() {
@@ -56,10 +57,15 @@ async function processUserGeneration(sessionName, userInput) {
 
   const folder = await createOrFindFolder(sessionName);
   // A username can include "+N" to create N extra actors for the same user.
-  const userEntries = userInput
+  const parsedEntries = userInput
     .split(",")
-    .map(parseUserEntry)
-    .filter(entry => entry.username);
+    .map(parseUserEntry);
+  const invalidEntries = parsedEntries.filter(entry => entry.error);
+  const userEntries = parsedEntries.filter(entry => entry.username && !entry.error);
+
+  for (let invalidEntry of invalidEntries) {
+    ui.notifications.warn(`Skipped "${invalidEntry.raw}": ${invalidEntry.error}`);
+  }
 
   if (!userEntries.length) {
     ui.notifications.warn("No valid usernames were provided.");
@@ -67,18 +73,22 @@ async function processUserGeneration(sessionName, userInput) {
   }
 
   for (let userEntry of userEntries) {
-    const [user, password] = await createUser(userEntry.username, folder, userEntry.additionalActors);
+    const [user, password, actorCount] = await createUser(userEntry.username, folder, userEntry.additionalActors);
 
     const inviteURL = game.data.addresses.remote;
+    const escapedUsername = escapeHTML(userEntry.username);
+    const escapedPassword = escapeHTML(password);
+    const escapedInviteURL = escapeHTML(inviteURL);
 
     const content = `
-      <p><strong><i class="fa-solid fa-user"></i> User Created:</strong> ${userEntry.username}</p>
-      <p><strong><i class="fa-solid fa-key"></i> Password:</strong> <code>${password}</code></p>
+      <p><strong><i class="fa-solid fa-user"></i> User Created:</strong> ${escapedUsername}</p>
+      <p><strong><i class="fa-solid fa-users"></i> Actors Created:</strong> ${actorCount}</p>
+      <p><strong><i class="fa-solid fa-key"></i> Password:</strong> <code>${escapedPassword}</code></p>
       <p><strong><i class="fa-solid fa-link"></i> Invite Link:</strong> 
-        <a href="${inviteURL}" target="_blank">${inviteURL}</a>
+        <a href="${escapedInviteURL}" target="_blank" rel="noopener">${escapedInviteURL}</a>
       </p>
       <div style="margin-top: 0.5em;">
-        <button class="copyUserInfo" data-username="${userEntry.username}" data-password="${password}" data-url="${inviteURL}">
+        <button class="copyUserInfo" data-username="${escapedUsername}" data-password="${escapedPassword}" data-url="${escapedInviteURL}">
           <i class="fa-solid fa-clipboard"></i> Copy Info to Clipboard
         </button>
       </div>
@@ -134,12 +144,34 @@ Hooks.on("renderChatMessageHTML", (message, htmlElement) => {
 
 function parseUserEntry(entry) {
   // Keep "+N" as generation syntax only; the actual username stays clean.
-  const match = entry.trim().match(/^(.+?)(?:\+(\d+))?$/u);
+  const raw = entry.trim();
+  if (!raw) return { raw, username: "", additionalActors: 0 };
 
-  return {
-    username: match?.[1]?.trim() ?? "",
-    additionalActors: Number(match?.[2] ?? 0)
-  };
+  const plusIndex = raw.lastIndexOf("+");
+  if (plusIndex === -1) return { raw, username: raw, additionalActors: 0 };
+
+  const username = raw.slice(0, plusIndex).trim();
+  const actorCountText = raw.slice(plusIndex + 1).trim();
+
+  if (!username) {
+    return { raw, username: "", additionalActors: 0, error: "missing username before +N." };
+  }
+
+  if (!/^\d+$/u.test(actorCountText)) {
+    return { raw, username, additionalActors: 0, error: "use +N with a whole number, such as +1 or +2." };
+  }
+
+  const additionalActors = Number(actorCountText);
+  if (additionalActors > MAX_ADDITIONAL_ACTORS) {
+    return {
+      raw,
+      username,
+      additionalActors: 0,
+      error: `maximum extra actors per user is ${MAX_ADDITIONAL_ACTORS}.`
+    };
+  }
+
+  return { raw, username, additionalActors };
 }
 
 // Actor folder logic
@@ -158,17 +190,32 @@ async function createUser(username, folder, additionalActors = 0) {
   const actor = await Actor.create({ name: username, type: "character", folder: folder.id });
   const user = await User.create({ name: username, password, character: actor.id, color });
 
-  let owner_obj = {};
-  owner_obj[user.id] = 3; // Owner
-  await actor.update({ ownership: owner_obj });
+  const ownership = {
+    default: CONST.DOCUMENT_OWNERSHIP_LEVELS?.NONE ?? 0,
+    [user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS?.OWNER ?? 3
+  };
+  await actor.update({ ownership });
 
   // Extra actors use the same owner but do not create additional users.
+  const extraActorData = [];
   for (let i = 1; i <= additionalActors; i++) {
-    const extraActor = await Actor.create({ name: `${username} ${i}`, type: "character", folder: folder.id });
-    await extraActor.update({ ownership: owner_obj });
+    extraActorData.push({ name: `${username} ${i}`, type: "character", folder: folder.id, ownership });
   }
 
-  return [user, password];
+  const extraActors = extraActorData.length ? await Actor.createDocuments(extraActorData) : [];
+  return [user, password, 1 + extraActors.length];
+}
+
+function escapeHTML(value) {
+  if (foundry.utils.escapeHTML) return foundry.utils.escapeHTML(String(value));
+
+  return String(value).replace(/[&<>"']/g, character => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;"
+  }[character]));
 }
 
 // Generate password locally (avoids CORS failures from browser fetch)

--- a/src/createUsers.js
+++ b/src/createUsers.js
@@ -55,29 +55,30 @@ async function processUserGeneration(sessionName, userInput) {
   }
 
   const folder = await createOrFindFolder(sessionName);
-  const userNames = userInput
+  // A username can include "+N" to create N extra actors for the same user.
+  const userEntries = userInput
     .split(",")
-    .map(name => name.trim())
-    .filter(Boolean);
+    .map(parseUserEntry)
+    .filter(entry => entry.username);
 
-  if (!userNames.length) {
+  if (!userEntries.length) {
     ui.notifications.warn("No valid usernames were provided.");
     return;
   }
 
-  for (let username of userNames) {
-    const [user, password] = await createUser(username, folder);
+  for (let userEntry of userEntries) {
+    const [user, password] = await createUser(userEntry.username, folder, userEntry.additionalActors);
 
     const inviteURL = game.data.addresses.remote;
 
     const content = `
-      <p><strong><i class="fa-solid fa-user"></i> User Created:</strong> ${username}</p>
+      <p><strong><i class="fa-solid fa-user"></i> User Created:</strong> ${userEntry.username}</p>
       <p><strong><i class="fa-solid fa-key"></i> Password:</strong> <code>${password}</code></p>
       <p><strong><i class="fa-solid fa-link"></i> Invite Link:</strong> 
         <a href="${inviteURL}" target="_blank">${inviteURL}</a>
       </p>
       <div style="margin-top: 0.5em;">
-        <button class="copyUserInfo" data-username="${username}" data-password="${password}" data-url="${inviteURL}">
+        <button class="copyUserInfo" data-username="${userEntry.username}" data-password="${password}" data-url="${inviteURL}">
           <i class="fa-solid fa-clipboard"></i> Copy Info to Clipboard
         </button>
       </div>
@@ -93,7 +94,7 @@ async function processUserGeneration(sessionName, userInput) {
   }
 }
 
-// ✅ Clipboard listener (whisper-compatible and native DOM-safe)
+// Clipboard listener (whisper-compatible and native DOM-safe)
 Hooks.on("renderChatMessageHTML", (message, htmlElement) => {
   if (!game.user.isGM) return;
 
@@ -131,6 +132,16 @@ Hooks.on("renderChatMessageHTML", (message, htmlElement) => {
   });
 });
 
+function parseUserEntry(entry) {
+  // Keep "+N" as generation syntax only; the actual username stays clean.
+  const match = entry.trim().match(/^(.+?)(?:\+(\d+))?$/u);
+
+  return {
+    username: match?.[1]?.trim() ?? "",
+    additionalActors: Number(match?.[2] ?? 0)
+  };
+}
+
 // Actor folder logic
 async function createOrFindFolder(sessionName) {
   let folder = game.folders.find(f => f.name === sessionName && f.type === "Actor");
@@ -141,7 +152,7 @@ async function createOrFindFolder(sessionName) {
 }
 
 // Create user and link to actor
-async function createUser(username, folder) {
+async function createUser(username, folder, additionalActors = 0) {
   const password = await fetchPassword();
   const color = await fetchRandomColor();
   const actor = await Actor.create({ name: username, type: "character", folder: folder.id });
@@ -150,6 +161,12 @@ async function createUser(username, folder) {
   let owner_obj = {};
   owner_obj[user.id] = 3; // Owner
   await actor.update({ ownership: owner_obj });
+
+  // Extra actors use the same owner but do not create additional users.
+  for (let i = 1; i <= additionalActors; i++) {
+    const extraActor = await Actor.create({ name: `${username} ${i}`, type: "character", folder: folder.id });
+    await extraActor.update({ ownership: owner_obj });
+  }
 
   return [user, password];
 }

--- a/src/importActors.js
+++ b/src/importActors.js
@@ -1,19 +1,16 @@
 
-import { getGitHubSettings, getActorFolders } from "./utils.js";
+import {
+    buildGitHubContentsUrl,
+    buildGitHubPathOptions,
+    escapeHtml,
+    fetchGitHubFolderList,
+    getActorFolders,
+    getDefaultGitHubPath,
+    getDialogElement,
+    getGitHubSettings,
+    normalizeGitHubPath
+} from "./utils.js";
 const MODULE_ID = "character-vault";
-
-function escapeHtml(value) {
-    return String(value ?? "").replace(/[&<>"']/g, char => {
-        switch (char) {
-            case "&": return "&amp;";
-            case "<": return "&lt;";
-            case ">": return "&gt;";
-            case "\"": return "&quot;";
-            case "'": return "&#39;";
-            default: return char;
-        }
-    });
-}
 
 function decodeBase64Utf8(base64Content) {
     const binary = atob(base64Content ?? "");
@@ -26,12 +23,12 @@ function decodeBase64Utf8(base64Content) {
     return decodeURIComponent(encoded);
 }
 
-
 // Get list of actors from GitHub, showing actual names from JSON content
-export async function fetchGitHubActorList() {
-    const { repo, path, yourPAT } = getGitHubSettings();
+export async function fetchGitHubActorList(pathOverride = null) {
+    const { repo, path: defaultPath, yourPAT } = getGitHubSettings();
+    const path = normalizeGitHubPath(pathOverride ?? defaultPath);
 
-    const url = `https://api.github.com/repos/${repo}/contents/${path}`;
+    const url = buildGitHubContentsUrl(repo, path);
     const response = await fetch(url, {
         method: 'GET',
         headers: {
@@ -46,7 +43,7 @@ export async function fetchGitHubActorList() {
         const jsonFiles = files.filter(file => file.name.endsWith('.json'));
         // Fetch all file contents in parallel
         const actorPromises = jsonFiles.map(async (file) => {
-            const fileResponse = await fetch(`https://api.github.com/repos/${repo}/contents/${path}/${file.name}`, {
+            const fileResponse = await fetch(buildGitHubContentsUrl(repo, path, file.name), {
                 method: 'GET',
                 headers: {
                     'Authorization': `token ${yourPAT}`
@@ -76,7 +73,10 @@ export async function fetchGitHubActorList() {
 // Single Actor import function for use in right click context menu
 export async function openImportDialog(preselectedActorId = null) {
 
-    const githubActors = await fetchGitHubActorList();
+    const githubPaths = await fetchGitHubFolderList();
+    const defaultPath = getDefaultGitHubPath();
+    const initialPath = githubPaths.includes(defaultPath) ? defaultPath : githubPaths[0];
+    const githubActors = await fetchGitHubActorList(initialPath);
     const githubChoices = githubActors.reduce((acc, actor) => {
         acc[actor.fileName] = actor.name;
         return acc;
@@ -91,6 +91,7 @@ export async function openImportDialog(preselectedActorId = null) {
     const githubActorOptions = Object.entries(githubChoices).map(([value, name]) =>
         `<option value="${escapeHtml(value)}">${escapeHtml(name)}</option>`
     ).join('');
+    const githubPathOptions = buildGitHubPathOptions(githubPaths, initialPath);
     const foundryActorOptions = Object.entries(foundryChoices).map(([value, name]) =>
         `<option value="${escapeHtml(value)}"${value === preselectedActorId ? " selected" : ""}>${escapeHtml(name)}</option>`
     ).join('');
@@ -98,8 +99,12 @@ export async function openImportDialog(preselectedActorId = null) {
     const content = `
         <form>
             <div class="form-group">
+                <label>GitHub Path:</label>
+                <select name="githubPath" data-github-path-select>${githubPathOptions}</select>
+            </div>
+            <div class="form-group">
                 <label>GitHub Actors:</label>
-                <select name="githubActor">${githubActorOptions}</select>
+                <select name="githubActor" data-github-actor-select>${githubActorOptions}</select>
             </div>
             <div class="form-group">
                 <label>Foundry Actors:</label>
@@ -112,15 +117,39 @@ export async function openImportDialog(preselectedActorId = null) {
         title: "Import Actor from GitHub",
         content: content,
         modal: true,
+        render: (event, target) => {
+            const root = getDialogElement(target);
+            if (!root) return;
+
+            const pathSelect = root.querySelector("[data-github-path-select]");
+            const actorSelect = root.querySelector("[data-github-actor-select]");
+            const actorCache = new Map([[initialPath, githubActors]]);
+
+            pathSelect?.addEventListener("change", async () => {
+                const selectedPath = normalizeGitHubPath(pathSelect.value);
+                actorSelect.disabled = true;
+
+                if (!actorCache.has(selectedPath)) {
+                    actorCache.set(selectedPath, await fetchGitHubActorList(selectedPath));
+                }
+
+                const actors = actorCache.get(selectedPath);
+                actorSelect.innerHTML = actors.map(actor =>
+                    `<option value="${escapeHtml(actor.fileName)}">${escapeHtml(actor.name)}</option>`
+                ).join("");
+                actorSelect.disabled = false;
+            });
+        },
         ok: {
             label: "Import",
             callback: async (event, button, html) => {
                 const form = button.form; // Get the form from the button context
                 const formData = new FormData(form);
+                const selectedGithubPath = formData.get("githubPath");
                 const selectedGithubActor = formData.get("githubActor");
                 const selectedFoundryActor = formData.get("foundryActor");
-                if (selectedGithubActor && selectedFoundryActor) {
-                    await importActorFromGitHubToActor(selectedGithubActor, selectedFoundryActor);
+                if (selectedGithubPath !== null && selectedGithubActor && selectedFoundryActor) {
+                    await importActorFromGitHubToActor(selectedGithubActor, selectedFoundryActor, selectedGithubPath);
                 }
             }
         },
@@ -132,26 +161,35 @@ export async function openImportDialog(preselectedActorId = null) {
 
 // Multiple Actors Import for UI button
 export async function openFolderImportDialog() {
-    const actorList = await fetchGitHubActorList();
     const folder = await promptForActorFolder();
 
     if (!folder) return;
+
+    const githubPaths = await fetchGitHubFolderList();
+    const defaultPath = getDefaultGitHubPath();
+    const initialPath = githubPaths.includes(defaultPath) ? defaultPath : githubPaths[0];
+    const actorList = await fetchGitHubActorList(initialPath);
 
     // Reduce GitHub actors into a choices object
     const githubChoices = actorList.reduce((acc, actor) => {
         acc[actor.fileName] = actor.name;
         return acc;
     }, {});
+    const githubPathOptions = buildGitHubPathOptions(githubPaths, initialPath);
+    const githubActorOptions = Object.entries(githubChoices).map(([fileName, name]) =>
+        `<option value="${escapeHtml(fileName)}">${escapeHtml(name)}</option>`
+    ).join('');
 
     // Form field for each actor in the folder
     const folderActorFields = folder.contents.map(actor => {
         return `
             <div class="form-group">
                 <label>${escapeHtml(actor.name)}</label>
-                <select name="${escapeHtml(actor.id)}">
-                    ${Object.entries(githubChoices).map(([fileName, name]) =>
-            `<option value="${escapeHtml(fileName)}">${escapeHtml(name)}</option>`
-        ).join('')}
+                <select name="${escapeHtml(actor.id)}-path" data-github-path-select>
+                    ${githubPathOptions}
+                </select>
+                <select name="${escapeHtml(actor.id)}-file" data-github-actor-select>
+                    ${githubActorOptions}
                 </select>
             </div>
         `;
@@ -163,6 +201,32 @@ export async function openFolderImportDialog() {
         title: "Import Actors from GitHub",
         content: content,
         modal: true,
+        render: (event, target) => {
+            const root = getDialogElement(target);
+            if (!root) return;
+
+            const actorCache = new Map([[initialPath, actorList]]);
+
+            for (const pathSelect of root.querySelectorAll("[data-github-path-select]")) {
+                const actorSelect = pathSelect.parentElement?.querySelector("[data-github-actor-select]");
+                if (!actorSelect) continue;
+
+                pathSelect.addEventListener("change", async () => {
+                    const selectedPath = normalizeGitHubPath(pathSelect.value);
+                    actorSelect.disabled = true;
+
+                    if (!actorCache.has(selectedPath)) {
+                        actorCache.set(selectedPath, await fetchGitHubActorList(selectedPath));
+                    }
+
+                    const actors = actorCache.get(selectedPath);
+                    actorSelect.innerHTML = actors.map(actor =>
+                        `<option value="${escapeHtml(actor.fileName)}">${escapeHtml(actor.name)}</option>`
+                    ).join("");
+                    actorSelect.disabled = false;
+                });
+            }
+        },
         ok: {
             label: "Import",
             callback: async (event, button, html) => {
@@ -170,9 +234,10 @@ export async function openFolderImportDialog() {
                 const formData = new FormData(form);
 
                 for (const actor of folder.contents) {
-                    const selectedFile = formData.get(actor.id);
-                    if (selectedFile) {
-                        await importActorFromGitHubToActor(selectedFile, actor.id);
+                    const selectedPath = formData.get(`${actor.id}-path`);
+                    const selectedFile = formData.get(`${actor.id}-file`);
+                    if (selectedPath !== null && selectedFile) {
+                        await importActorFromGitHubToActor(selectedFile, actor.id, selectedPath);
                     }
                 }
             }
@@ -185,7 +250,7 @@ export async function openFolderImportDialog() {
             icon: "fa-solid fa-upload"
         },
         position: {
-            width: 400,
+            width: 600,
             height: "auto"
         }
     });
@@ -236,7 +301,7 @@ export async function promptForActorFolder() {
                 icon: "fa-solid fa-folder-open"
             },
             position: {
-                width: 400,
+                width: 600,
                 height: "auto"
             }
         });
@@ -244,12 +309,12 @@ export async function promptForActorFolder() {
 }
 
 // Function to import the actor from GitHub to Foundry using the built-in importFromJSON function
-export async function importActorFromGitHubToActor(fileName, actorId) {
+export async function importActorFromGitHubToActor(fileName, actorId, pathOverride = null) {
     const repo = game.settings.get(MODULE_ID, "githubRepo");
-    const path = game.settings.get(MODULE_ID, "githubPath");
+    const path = normalizeGitHubPath(pathOverride ?? game.settings.get(MODULE_ID, "githubPath"));
     const yourPAT = game.settings.get(MODULE_ID, "githubPAT");
 
-    const url = `https://api.github.com/repos/${repo}/contents/${path}/${encodeURIComponent(fileName)}`;
+    const url = buildGitHubContentsUrl(repo, path, fileName);
     const response = await fetch(url, {
         method: 'GET',
         headers: {
@@ -273,7 +338,6 @@ export async function importActorFromGitHubToActor(fileName, actorId) {
         try {
             // Use the importFromJSON function to import the data
             await actor.importFromJSON(jsonContent);
-            ui.notifications.info(`Actor ${actor.name} has been successfully imported and updated.`);
         } catch (error) {
             console.error('Failed to import actor:', error);
             ui.notifications.error('Failed to import actor from JSON.');

--- a/src/uploadActors.js
+++ b/src/uploadActors.js
@@ -1,8 +1,14 @@
 
 import {
+    buildGitHubContentsUrl,
+    buildGitHubPathOptions,
+    escapeHtml,
+    fetchGitHubFolderList,
     getActorFolders,
+    getDefaultGitHubPath,
     getGitHubSettings,
     getSanitizedActorFileName,
+    normalizeGitHubPath,
     toBase64
 } from "./utils.js";
 
@@ -14,19 +20,31 @@ export async function openFolderUploadDialog() {
         return;
     }
 
-    const choices = getActorFolders().reduce((acc, folder) => {
+    const folderChoices = getActorFolders().reduce((acc, folder) => {
         acc[folder.id] = folder.name;
         return acc;
     }, {});
+    const githubPaths = await fetchGitHubFolderList();
+    const defaultPath = getDefaultGitHubPath();
+    const initialPath = githubPaths.includes(defaultPath) ? defaultPath : githubPaths[0];
+    const githubPathOptions = buildGitHubPathOptions(githubPaths, initialPath);
 
-    const input = new foundry.data.fields.StringField({
-        required: true,
-        choices: choices,
-        label: "Folder",
-        hint: "Select a folder to upload all actors from it to GitHub."
-    }).toFormGroup({}, { name: "folderId" }).outerHTML;
-
-    const content = `<fieldset>${input}</fieldset>`;
+    const content = `
+        <form>
+            <div class="form-group">
+                <label>Folder</label>
+                <select name="folderId">
+                    ${Object.entries(folderChoices).map(([id, name]) =>
+        `<option value="${escapeHtml(id)}">${escapeHtml(name)}</option>`
+    ).join("")}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>GitHub Path</label>
+                <select name="githubPath">${githubPathOptions}</select>
+            </div>
+        </form>
+    `;
 
     await foundry.applications.api.DialogV2.prompt({
         content: content,
@@ -35,8 +53,9 @@ export async function openFolderUploadDialog() {
             label: "Upload",
             callback: async (event, button, html) => {
                 const id = button.form.elements.folderId.value;
+                const path = button.form.elements.githubPath.value;
                 const folder = game.folders.get(id);
-                uploadActorsFromFolderToGitHub(folder);
+                uploadActorsFromFolderToGitHub(folder, path);
             }
         },
         window: {
@@ -50,21 +69,71 @@ export async function openFolderUploadDialog() {
     });
 }
 
-// Step 3: Function to Upload Actors from Selected Folder
-export async function uploadActorsFromFolderToGitHub(folder) {
+export async function openActorUploadDialog(actor) {
     if (!game.user.isGM) {
         ui.notifications.error("Only a GM can upload actors to GitHub.");
         return;
     }
 
-    const { repo, path, yourPAT } = getGitHubSettings();
+    const githubPaths = await fetchGitHubFolderList();
+    const defaultPath = getDefaultGitHubPath();
+    const initialPath = githubPaths.includes(defaultPath) ? defaultPath : githubPaths[0];
+    const githubPathOptions = buildGitHubPathOptions(githubPaths, initialPath);
+
+    const content = `
+        <form>
+            <div class="form-group">
+                <label>Actor</label>
+                <div>${escapeHtml(actor.name)}</div>
+            </div>
+            <div class="form-group">
+                <label>GitHub Path</label>
+                <select name="githubPath">${githubPathOptions}</select>
+            </div>
+        </form>
+    `;
+
+    await foundry.applications.api.DialogV2.prompt({
+        content,
+        modal: true,
+        ok: {
+            label: "Upload",
+            callback: async (event, button) => {
+                await uploadActorToGitHub(actor, button.form.elements.githubPath.value);
+            }
+        },
+        cancel: {
+            label: "Cancel"
+        },
+        window: {
+            title: "Upload Actor",
+            icon: "fa-solid fa-upload"
+        },
+        position: {
+            width: 400,
+            height: "auto"
+        }
+    });
+}
+
+// Step 3: Function to Upload Actors from Selected Folder
+export async function uploadActorsFromFolderToGitHub(folder, pathOverride = null) {
+    if (!game.user.isGM) {
+        ui.notifications.error("Only a GM can upload actors to GitHub.");
+        return;
+    }
+
+    const { repo, path: defaultPath, yourPAT } = getGitHubSettings();
+    const path = normalizeGitHubPath(pathOverride ?? defaultPath);
+    const existingShas = await fetchExistingGitHubFileShas(repo, path, yourPAT);
 
     for (let actor of folder.contents) {
         const jsonContent = JSON.stringify(actor.toJSON());
-        const success = await uploadToGitHub(actor, jsonContent, repo, path, yourPAT);
+        const fileName = getSanitizedActorFileName(actor);
+        const success = await uploadToGitHub(actor, jsonContent, repo, path, yourPAT, existingShas.get(fileName) ?? null);
 
         if (success) {
-            ui.notifications.info(`Actor ${actor.name} has been successfully uploaded to GitHub.`);
+            ui.notifications.info(`${actor.name} has been successfully uploaded to GitHub.`);
         } else {
             ui.notifications.error(`Failed to upload actor ${actor.name} to GitHub.`);
         }
@@ -72,19 +141,22 @@ export async function uploadActorsFromFolderToGitHub(folder) {
 }
 
 // Step 4: Function to Upload a Single Actor to GitHub
-export async function uploadActorToGitHub(actor) {
+export async function uploadActorToGitHub(actor, pathOverride = null) {
     if (!game.user.isGM) {
         ui.notifications.error("Only a GM can upload actors to GitHub.");
         return;
     }
 
-    const { repo, path, yourPAT } = getGitHubSettings();
+    const { repo, path: defaultPath, yourPAT } = getGitHubSettings();
+    const path = normalizeGitHubPath(pathOverride ?? defaultPath);
+    const existingShas = await fetchExistingGitHubFileShas(repo, path, yourPAT);
+    const fileName = getSanitizedActorFileName(actor);
 
     const jsonContent = JSON.stringify(actor.toJSON());
-    const success = await uploadToGitHub(actor, jsonContent, repo, path, yourPAT);
+    const success = await uploadToGitHub(actor, jsonContent, repo, path, yourPAT, existingShas.get(fileName) ?? null);
 
     if (success) {
-        ui.notifications.info(`Actor ${actor.name} has been successfully uploaded to GitHub.`);
+        ui.notifications.info(`${actor.name} has been successfully uploaded to GitHub.`);
     } else {
         ui.notifications.error(`Failed to upload actor ${actor.name} to GitHub.`);
     }
@@ -92,53 +164,62 @@ export async function uploadActorToGitHub(actor) {
 
 // Step 5: Function to Upload to GitHub
 
-export async function uploadToGitHub(actor, jsonContent, repo, path, yourPAT) {
-    if (!game.user.isGM) {
-        ui.notifications.error("Only a GM can upload actors to GitHub.");
-        return false;
-    }
+async function fetchExistingGitHubFileShas(repo, path, yourPAT) {
+    const shas = new Map();
 
-    const encodedName = getSanitizedActorFileName(actor);
-    const url = `https://api.github.com/repos/${repo}/contents/${path}/${encodedName}`;
-
-    let sha = null;
-
-    // Step 1: Check if the file already exists on GitHub to get its SHA
     try {
-        const checkResponse = await fetch(url, {
+        const response = await fetch(buildGitHubContentsUrl(repo, path), {
             method: 'GET',
             headers: {
                 'Authorization': `token ${yourPAT}`,
             }
         });
 
-        if (checkResponse.ok) {
-            const data = await checkResponse.json();
-            sha = data.sha; // Get the current sha value for updating
+        if (!response.ok) return shas;
+
+        const entries = await response.json();
+        if (!Array.isArray(entries)) return shas;
+
+        for (const entry of entries) {
+            if (entry.type === "file" && entry.name?.endsWith(".json")) {
+                shas.set(entry.name, entry.sha);
+            }
         }
     } catch (error) {
-        console.error('Check file error:', error);
+        console.error('Folder contents check error:', error);
+    }
+
+    return shas;
+}
+
+export async function uploadToGitHub(actor, jsonContent, repo, path, yourPAT, sha = null) {
+    if (!game.user.isGM) {
+        ui.notifications.error("Only a GM can upload actors to GitHub.");
         return false;
     }
 
+    const fileName = getSanitizedActorFileName(actor);
+    const url = buildGitHubContentsUrl(repo, path, fileName);
+
     // Step 2: Upload the actor data to GitHub
     try {
+        const body = {
+            message: `Updating character ${actor.name}`,
+            content: toBase64(jsonContent), // Convert JSON content to base64
+            branch: "main",
+        };
+        if (sha) body.sha = sha;
+
         const response = await fetch(url, {
             method: 'PUT',
             headers: {
                 'Authorization': `token ${yourPAT}`,
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-                message: `Updating character ${actor.name}`,
-                content: toBase64(jsonContent), // Convert JSON content to base64
-                sha: sha,  // Include sha if the file exists (update)
-                branch: "main",
-            }),
+            body: JSON.stringify(body),
         });
 
         if (response.ok) {
-            console.log(`${actor.name} has been exported to GitHub.`);
             return true;
         } else {
             console.error('Upload error:', await response.text());
@@ -149,4 +230,3 @@ export async function uploadToGitHub(actor, jsonContent, repo, path, yourPAT) {
         return false;
     }
 }
-

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,108 @@ export function getGitHubSettings() {
     };
 }
 
+export function escapeHtml(value) {
+    return String(value ?? "").replace(/[&<>"']/g, char => {
+        switch (char) {
+            case "&": return "&amp;";
+            case "<": return "&lt;";
+            case ">": return "&gt;";
+            case "\"": return "&quot;";
+            case "'": return "&#39;";
+            default: return char;
+        }
+    });
+}
+
+export function normalizeGitHubPath(path) {
+    return String(path ?? "").trim().replace(/^\/+|\/+$/g, "");
+}
+
+export function encodeGitHubPath(path) {
+    return normalizeGitHubPath(path)
+        .split("/")
+        .filter(Boolean)
+        .map(segment => encodeURIComponent(segment))
+        .join("/");
+}
+
+export function buildGitHubContentsUrl(repo, path, fileName = null) {
+    const encodedPath = encodeGitHubPath(path);
+    const parts = [`https://api.github.com/repos/${repo}/contents`];
+
+    if (encodedPath) parts.push(encodedPath);
+    if (fileName) parts.push(encodeURIComponent(fileName));
+
+    return parts.join("/");
+}
+
+export function getDefaultGitHubPath() {
+    return normalizeGitHubPath(game.settings.get(MODULE_ID, "githubPath"));
+}
+
+export function buildGitHubPathOptions(paths, selectedPath) {
+    const selected = normalizeGitHubPath(selectedPath);
+
+    return paths.map(path => {
+        const normalized = normalizeGitHubPath(path);
+        const label = normalized || "/";
+        return `<option value="${escapeHtml(normalized)}"${normalized === selected ? " selected" : ""}>${escapeHtml(label)}</option>`;
+    }).join("");
+}
+
+function dedupeGitHubPaths(paths) {
+    return [...new Set(paths.map(normalizeGitHubPath))].sort((a, b) => a.localeCompare(b));
+}
+
+function isVisibleGitHubPath(path) {
+    return normalizeGitHubPath(path)
+        .split("/")
+        .filter(Boolean)
+        .every(segment => !segment.startsWith("."));
+}
+
+export async function fetchGitHubFolderList() {
+    const { repo, path, yourPAT } = getGitHubSettings();
+    const defaultPath = normalizeGitHubPath(path);
+    const folders = new Set([defaultPath]);
+    const url = `https://api.github.com/repos/${repo}/git/trees/main?recursive=1`;
+
+    try {
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': `token ${yourPAT}`,
+            }
+        });
+
+        if (!response.ok) {
+            console.error('Error fetching GitHub folder list:', response.statusText);
+            return dedupeGitHubPaths([...folders]);
+        }
+
+        const data = await response.json();
+        for (const entry of data.tree ?? []) {
+            if (entry.type === "tree") {
+                if (isVisibleGitHubPath(entry.path)) folders.add(entry.path);
+            } else if (entry.type === "blob" && entry.path?.endsWith(".json")) {
+                const parentPath = entry.path.split("/").slice(0, -1).join("/");
+                if (isVisibleGitHubPath(parentPath)) folders.add(parentPath);
+            }
+        }
+    } catch (error) {
+        console.error('Failed to fetch GitHub folder list:', error);
+    }
+
+    return dedupeGitHubPaths([...folders]);
+}
+
+export function getDialogElement(target) {
+    if (target instanceof HTMLElement) return target;
+    if (target?.[0] instanceof HTMLElement) return target[0];
+    if (target?.element instanceof HTMLElement) return target.element;
+    return null;
+}
+
 // Get all actor folders
 export function getActorFolders() {
     return game.folders.filter(f => f.type === "Actor");
@@ -20,7 +122,7 @@ export function getActorFolders() {
 export function getSanitizedActorFileName(actor) {
     // Use Foundry VTT v13's string.slugify method with recommended options
     const slug = actor.name.slugify({ lowercase: true, replacement: "-", strict: true });
-    return encodeURIComponent(slug + ".json");
+    return slug + ".json";
 }
 
 // Base64 encode string for GitHub API


### PR DESCRIPTION
Use a `+N` to create additional actors for a user: e.g., Valeros+2,Seoni,Kyra creates two additional actors assigned to Valeros. Helpful for heroes with followers or summons. Closes #17